### PR TITLE
Use UTF-8 encoding when reading `doc.json`

### DIFF
--- a/sphinx_lua_ls/lua_ls.py
+++ b/sphinx_lua_ls/lua_ls.py
@@ -192,7 +192,9 @@ class LuaLs:
                 _logger.error("%s", err, type="lua-ls")
                 raise err from None
 
-            return json.loads(pathlib.Path(output_path, "doc.json").read_text())
+            return json.loads(
+                pathlib.Path(output_path, "doc.json").read_text(encoding="utf-8")
+            )
 
 
 class ProgressReporter:


### PR DESCRIPTION
I ran into the following error when generating docs for my project:

```
    sphinx.errors.ExtensionError: Handler <function run_lua_ls at 0x000001CA532368D0> for event 'builder-inited' threw an exception (exception: 'cp932' codec can't decode byte 0x94 in position 27401: illegal multibyte sequence)
```

From some reading on the error, I found this had to do with my PC being set to the Japanese locale (cp932 means Code Page 932). 

Changing the return statement in the `run` function of `lua_ls.py` to use UTF-8 encoding fixed it (which this PR includes)

```python
return json.loads(
     pathlib.Path(output_path, "doc.json").read_text(encoding="utf-8") # Add `encoding="utf-8"`
)
```

I only verified it working for the Japanese codec, but I assume this should fix encoding errors in other languages